### PR TITLE
10:responsive-dialog

### DIFF
--- a/src/components/responsive-dialog.tsx
+++ b/src/components/responsive-dialog.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Drawer, DrawerContent, DrawerDescription, DrawerHeader, DrawerTitle } from "@/components/ui/drawer";
+import { useIsMobile } from "@/hooks/use-mobile";
+
+interface ResponsiveDialogProps {
+    title: string;
+    description: string;
+    children: React.ReactNode;
+    open: boolean;
+    openChange: (open: boolean) => void;
+}
+
+export const ResponsiveDialog = ({children, description, open, openChange, title}: ResponsiveDialogProps) => {
+    const isMobile = useIsMobile();
+    if(isMobile){
+        return (
+            <Drawer open={open} onOpenChange={openChange}>
+                <DrawerContent>
+                    <DrawerHeader>
+                        <DrawerTitle>{title}</DrawerTitle>
+                        <DrawerDescription>{description}</DrawerDescription>
+                    </DrawerHeader>
+                    <div className="p-4">
+                        {children}
+                    </div>
+                </DrawerContent>
+            </Drawer>
+        )
+    }
+
+    return (
+        <Dialog open={open} onOpenChange={openChange}>
+            <DialogContent>
+                <DialogHeader>
+                    <DialogTitle>{title}</DialogTitle>
+                    <DialogDescription>{description}</DialogDescription>
+                </DialogHeader>
+                {children}
+            </DialogContent>
+        </Dialog>
+    )
+}

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -12,6 +12,8 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog"
+import { useIsMobile } from "@/hooks/use-mobile"
+import { Drawer, DrawerContent, DrawerDescription, DrawerHeader, DrawerTitle } from "./drawer"
 
 function Command({
   className,
@@ -42,6 +44,55 @@ function CommandDialog({
   className?: string
   showCloseButton?: boolean
 }) {
+  return (
+    <Dialog {...props}>
+      <DialogHeader className="sr-only">
+        <DialogTitle>{title}</DialogTitle>
+        <DialogDescription>{description}</DialogDescription>
+      </DialogHeader>
+      <DialogContent
+        className={cn("overflow-hidden p-0", className)}
+        showCloseButton={showCloseButton}
+      >
+        <Command className="[&_[cmdk-group-heading]]:text-muted-foreground **:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
+          {children}
+        </Command>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function CommandResponsiveDialog({
+  title = "Command Palette",
+  description = "Search for a command to run...",
+  children,
+  className,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof Dialog> & {
+  title?: string
+  description?: string
+  className?: string
+  showCloseButton?: boolean
+}) {
+  const isMobile = useIsMobile();
+
+  if(isMobile){
+    return (
+      <Drawer {...props}>
+        <DrawerContent className="overflow-hidden p-0">
+          <DrawerHeader className="sr-only">
+            <DrawerTitle>{title}</DrawerTitle>
+            <DrawerDescription>{description}</DrawerDescription>
+          </DrawerHeader>
+          <Command className="[&_[cmdk-group-heading]]:text-muted-foreground **:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
+            {children}
+          </Command>
+        </DrawerContent>
+      </Drawer>
+    )
+  }
+
   return (
     <Dialog {...props}>
       <DialogHeader className="sr-only">
@@ -181,4 +232,5 @@ export {
   CommandItem,
   CommandShortcut,
   CommandSeparator,
+  CommandResponsiveDialog
 }

--- a/src/modules/dashboard/ui/components/dashboard-command.tsx
+++ b/src/modules/dashboard/ui/components/dashboard-command.tsx
@@ -1,4 +1,4 @@
-import { CommandDialog, CommandInput, CommandItem, CommandList } from "@/components/ui/command"
+import { CommandInput, CommandItem, CommandList, CommandResponsiveDialog } from "@/components/ui/command"
 import { Dispatch, SetStateAction } from "react";
 
 interface Props {
@@ -8,7 +8,7 @@ interface Props {
 
 export const DashboardCommand = ({open, setOpen}: Props) => {
     return (
-        <CommandDialog open={open} onOpenChange={setOpen}>
+        <CommandResponsiveDialog open={open} onOpenChange={setOpen}>
             <CommandInput 
                 placeholder="Find a meeting or agent"
             />
@@ -17,6 +17,6 @@ export const DashboardCommand = ({open, setOpen}: Props) => {
                     Test
                 </CommandItem>
             </CommandList>
-        </CommandDialog>
+        </CommandResponsiveDialog>
     )
 }


### PR DESCRIPTION
### 1. Walkthrough: Summary of the Commit

**Commit message:** 10:responsive-dialog

**Summary:**  
This commit introduces a responsive dialog component (`ResponsiveDialog`) that renders as a modal dialog on desktop and as a drawer on mobile, using an `useIsMobile` hook for device detection. The command palette dialog system is refactored to use this new responsive approach, ensuring a better user experience across device sizes. The dashboard command UI now uses the responsive dialog, and the command UI logic is refactored for maintainability and consistency.

### 2. Changes Table

| File Name                                              | Change Summary                                                                                         |
|--------------------------------------------------------|--------------------------------------------------------------------------------------------------------|
| src/components/responsive-dialog.tsx                   | **New file:** Adds `ResponsiveDialog` component for mobile/desktop adaptive dialog/drawer UI.          |
| src/components/ui/command.tsx                          | **Modified:** Adds `CommandResponsiveDialog` using `ResponsiveDialog` logic, implements mobile drawer. |
| src/modules/dashboard/ui/components/dashboard-command.tsx | **Modified:** Switches from `CommandDialog` to new `CommandResponsiveDialog` for dashboard command UI. |

### 3. Sequence Diagram

```mermaid
sequenceDiagram
    participant User
    participant DashboardCommand (UI)
    participant CommandResponsiveDialog
    participant useIsMobile Hook
    participant Dialog/Drawer

    User->>DashboardCommand (UI): Triggers command palette (e.g., keyboard shortcut)
    DashboardCommand (UI)->>CommandResponsiveDialog: Renders with open state
    CommandResponsiveDialog->>useIsMobile Hook: Determines if device is mobile
    alt Mobile Device
        CommandResponsiveDialog->>Drawer: Render command UI inside drawer
    else Desktop Device
        CommandResponsiveDialog->>Dialog: Render command UI inside dialog
    end
    Dialog/Drawer->>User: Displays command interface
```