### PR TITLE
16: Meetings setup

### DIFF
--- a/src/app/(dashboard)/meetings/[meetingId]/page.tsx
+++ b/src/app/(dashboard)/meetings/[meetingId]/page.tsx
@@ -1,0 +1,9 @@
+import React from 'react'
+
+const page = () => {
+  return (
+    <div>meeting page id</div>
+  )
+}
+
+export default page

--- a/src/app/(dashboard)/meetings/page.tsx
+++ b/src/app/(dashboard)/meetings/page.tsx
@@ -1,0 +1,38 @@
+import { ErrorState } from '@/components/error-state';
+import { LoadingState } from '@/components/loading-state';
+import { auth } from '@/lib/auth';
+import { MeetingsView } from '@/modules/meetings/ui/views/meeting-view';
+import { getQueryClient, trpc } from '@/trpc/server';
+import { dehydrate, HydrationBoundary } from '@tanstack/react-query';
+import { headers } from 'next/headers';
+import { redirect } from 'next/navigation';
+import { Suspense } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
+
+const page = async () => {
+    const session = await auth.api.getSession({
+        headers: await headers()
+    });
+
+    if (!session) {
+        redirect('/sign-in')
+    }
+
+    const queryClient = getQueryClient();
+    void queryClient.prefetchQuery(trpc.meetings.getMany.queryOptions({}));
+
+    return (
+        <>
+            {/* <AgentsListHeader /> */}
+            <HydrationBoundary state={dehydrate(queryClient)}>
+                <Suspense fallback={<LoadingState title='Loading Meeting' description='This may take a few seconds' />}>
+                    <ErrorBoundary fallback={<ErrorState title='Error Loading Meeting' description='Please try again later' />}>
+                        <MeetingsView />
+                    </ErrorBoundary>
+                </Suspense>
+            </HydrationBoundary>
+        </>
+    )
+}
+
+export default page;

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,5 +1,5 @@
 import {nanoid} from "nanoid";
-import { pgTable, text, timestamp, boolean } from "drizzle-orm/pg-core";
+import { pgTable, text, timestamp, boolean, pgEnum } from "drizzle-orm/pg-core";
 
 export const user = pgTable("user", {
   id: text('id').primaryKey(),
@@ -52,6 +52,30 @@ export const agents = pgTable("agents", {
   name: text("name").notNull(),
   userId: text("user_id").notNull().references(() => user.id, { onDelete: 'cascade' }),
   instructions: text("instructions").notNull(),
+  createdAt: timestamp("created_at").notNull().defaultNow(),
+  updatedAt: timestamp("updated_at").notNull().defaultNow(),
+});
+
+export const meetingStatus = pgEnum('meeting_status', [
+  'upcoming',
+  'active',
+  'completed',
+  'processing',
+  'cancelled'
+])
+
+export const meetings = pgTable("meetings", {
+  id: text('id').primaryKey().$defaultFn(() => nanoid()),
+  name: text("name").notNull(),
+  userId: text("user_id").notNull().references(() => user.id, { onDelete: 'cascade' }),
+  agentId: text("agent_id").notNull().references(() => agents.id, { onDelete: 'cascade' }),
+  status: meetingStatus('status').notNull().default('upcoming'),
+  instructions: text("instructions").notNull(),
+  startedAt: timestamp("started_at"),
+  endeddAt: timestamp("ended_at"),
+  transcriptUrl: text("transcript_url"),
+  recordingUrl: text("recording_Url"),
+  summary: text("summary"),
   createdAt: timestamp("created_at").notNull().defaultNow(),
   updatedAt: timestamp("updated_at").notNull().defaultNow(),
 })

--- a/src/modules/meetings/server/procedure.ts
+++ b/src/modules/meetings/server/procedure.ts
@@ -1,0 +1,75 @@
+import { DEFAULT_PAGE, DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE, MIN_PAGE_SIZE } from "@/constants";
+import { db } from "@/db";
+import { meetings } from "@/db/schema";
+import { createTRPCRouter, protectedProcedure } from "@/trpc/init";
+import { and, count, desc, eq, getTableColumns, ilike } from "drizzle-orm";
+import { z } from "zod";
+import { TRPCError } from "@trpc/server";
+
+export const meetingsRouter = createTRPCRouter({
+    getOne: protectedProcedure.input(
+        z.object({ id: z.string() })).query(async ({ input, ctx }) => {
+            const [existingMeeting] = await db.select({
+                ...getTableColumns(meetings),
+            })
+                .from(meetings)
+                .where(
+                    and(
+                        eq(meetings.id, input.id),
+                        eq(meetings.userId, ctx.auth.user.id)
+                    )
+                );
+
+            if (!existingMeeting) {
+                throw new TRPCError({ code: "NOT_FOUND", message: "Meeting not found" })
+            }
+            return existingMeeting;
+        }),
+    getMany: protectedProcedure.input(
+        z.object({
+            page:
+                z.number()
+                    .default(DEFAULT_PAGE),
+            pageSize:
+                z.number()
+                    .min(MIN_PAGE_SIZE)
+                    .max(MAX_PAGE_SIZE)
+                    .default(DEFAULT_PAGE_SIZE),
+            search:
+                z.string()
+                    .nullish(),
+        }))
+        .query(async ({ ctx, input }) => {
+            const { page, pageSize, search } = input;
+            const data = await db.select({
+                ...getTableColumns(meetings),
+            })
+                .from(meetings)
+                .where(
+                    and(
+                        eq(meetings.userId, ctx.auth.session.userId),
+                        search ? ilike(meetings.name, `%${search}%`) : undefined
+                    )
+                )
+                .orderBy(desc(meetings.createdAt), desc(meetings.id))
+                .limit(pageSize)
+                .offset((page - 1) * pageSize);
+
+            const [total] = await db
+                .select({ count: count() })
+                .from(meetings)
+                .where(
+                    and(
+                        eq(meetings.userId, ctx.auth.session.userId),
+                        search ? ilike(meetings.name, `%${search}%`) : undefined
+                    )
+                )
+
+            const totalPages = Math.ceil(total.count / pageSize)
+            return {
+                items: data,
+                total: total.count,
+                totalPages,
+            };
+        }),
+})

--- a/src/modules/meetings/ui/views/meeting-view.tsx
+++ b/src/modules/meetings/ui/views/meeting-view.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { useTRPC } from "@/trpc/client";
+import { useSuspenseQuery } from "@tanstack/react-query";
+
+export const MeetingsView = () => {
+    const trpc = useTRPC();
+    const { data } = useSuspenseQuery(trpc.meetings.getMany.queryOptions({}));
+
+    return (
+        <div>
+            {JSON.stringify(data, null, 2)}
+        </div>
+    )
+}

--- a/src/trpc/routers/_app.ts
+++ b/src/trpc/routers/_app.ts
@@ -1,7 +1,9 @@
 import { agentsRouter } from '@/modules/agents/server/procedures';
+import { meetingsRouter } from '@/modules/meetings/server/procedure';
 import { createTRPCRouter } from '../init';
 export const appRouter = createTRPCRouter({
     agents: agentsRouter,
+    meetings: meetingsRouter,
 });
 // export type definition of API
 export type AppRouter = typeof appRouter;


### PR DESCRIPTION
### 1. Walkthrough: Overview of the Commit

**Commit Message:** 16: Meetings setup

This commit lays the foundation for the "Meetings" feature in the application. It introduces database schema changes to support meetings, adds backend procedures to fetch individual and multiple meetings, sets up the TRPC router for meetings, and scaffolds both the meetings list and detail pages on the dashboard. The initial UI simply lists meetings as JSON to verify the backend wiring.

### 2. Changes Table

| File Name                                                      | Change Summary                                                                                                         |
|---------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------|
| src/app/(dashboard)/meetings/[meetingId]/page.tsx              | **Added:** New dashboard route and page for displaying a specific meeting, currently a placeholder.                    |
| src/app/(dashboard)/meetings/page.tsx                          | **Added:** New dashboard route for listing meetings. Handles session auth, query prefetching, and hydration boundary.  |
| src/db/schema.ts                                               | **Modified:** Added `meetingStatus` enum and the `meetings` table with all related fields to the DB schema.            |
| src/modules/meetings/server/procedure.ts                       | **Added:** Backend TRPC router for meetings with `getOne` and `getMany` endpoints (pagination, search, access control).|
| src/modules/meetings/ui/views/meeting-view.tsx                 | **Added:** Minimal client-side component to display (as JSON) fetched meetings data.                                   |
| src/trpc/routers/_app.ts                                       | **Modified:** Registered `meetingsRouter` in the main TRPC app router.                                                |

### 3. Sequence Diagram

```mermaid
sequenceDiagram
    participant User
    participant MeetingsListPage
    participant TRPCClient
    participant MeetingsRouter
    participant DB

    User->>MeetingsListPage: Visit /dashboard/meetings
    MeetingsListPage->>TRPCClient: Fetch meetings list (getMany)
    TRPCClient->>MeetingsRouter: getMany({ page, pageSize, search })
    MeetingsRouter->>DB: Query meetings table for user (with pagination/search)
    DB-->>MeetingsRouter: Return meeting records
    MeetingsRouter-->>TRPCClient: Return meetings data
    TRPCClient-->>MeetingsListPage: Hydrate and render meetings data (as JSON)

    User->>MeetingsListPage: Click on a meeting
    MeetingsListPage->>MeetingDetailPage: Navigate to /dashboard/meetings/[meetingId]
    MeetingDetailPage->>TRPCClient: Fetch meeting by ID (getOne)
    TRPCClient->>MeetingsRouter: getOne({ id })
    MeetingsRouter->>DB: Query meeting by ID and user
    DB-->>MeetingsRouter: Return meeting record
    MeetingsRouter-->>TRPCClient: Return meeting data
    TRPCClient-->>MeetingDetailPage: Hydrate and render meeting info
```